### PR TITLE
Use .debug file for debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Configuration files with sensitive data
 private/config.php
 
+# Debug mode flag (create empty .debug file to enable)
+.debug
+
 # Claude Code instructions
 CLAUDE.md
 

--- a/private/config_draft.php
+++ b/private/config_draft.php
@@ -1,7 +1,4 @@
 <?php
-// Debug mode - set to true only for local development
-$debugMode = false;
-
 // Próba pobrania tokena z zmiennej środowiskowej (preferowane)
 $notionApiKey = getenv('NOTION_API_KEY');
 

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -3,18 +3,18 @@
 error_reporting(0);
 ini_set('display_errors', 0);
 
+// Enable debug mode if .debug file exists in project root
+if (file_exists(__DIR__ . '/../.debug')) {
+    error_reporting(E_ALL);
+    ini_set('display_errors', 1);
+}
+
 // --- START SESJI ---
 session_start();
 // --- KONIEC START SESJI ---
 
 // Include configuration (outside public directory)
 require_once '../private/config.php';
-
-// Enable error reporting only if debug mode is enabled in config
-if (isset($debugMode) && $debugMode === true) {
-    error_reporting(E_ALL);
-    ini_set('display_errors', 1);
-}
 // Include Notion helper functions
 require_once '../private/notion_utils.php';
 // Include security headers


### PR DESCRIPTION
## Summary

Simplifies debug mode configuration for easier deployment workflow.

## Changes

- Debug mode now enabled by creating empty `.debug` file in project root
- Removed `$debugMode` variable from config.php
- Added `.debug` to .gitignore

## Usage

**Local development:** create empty `.debug` file
```bash
touch .debug
```

**Production:** don't copy `.debug` file (or delete if exists)

## Test Plan

- [x] All 143 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies how debug mode is toggled and decouples it from app config.
> 
> - `public_html/index.php`: enables full error reporting when `../.debug` exists; default remains production-safe (errors hidden)
> - Removes `$debugMode` variable from `private/config_draft.php` and related check in `index.php`
> - `.gitignore`: adds `.debug` so the flag isn’t committed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a27fc43f87198a3c291507cd63e694c1a2bbbaff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->