### PR TITLE
feat: rate limiting and exponential backoff for Notion API

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -149,6 +149,9 @@ Tests for all Notion block types:
 - ✅ Probabilistic cleanup
 - ✅ Rich text with page mentions
 - ✅ External links
+- ✅ `notionApiRequest()` returns correct structure
+- ✅ `notionApiRequest()` handles 401 unauthorized (token expiration)
+- ✅ `notionApiRequest()` with maxRetries=0 (no retry)
 
 ### Functional Tests (tests/Functional/)
 


### PR DESCRIPTION
## Summary

- Add centralized `notionApiRequest()` function for all API calls
- Rate limiting: ~3 requests/second (Notion API limit)
- Exponential backoff for 429/5xx errors (2s, 4s, 8s delays)
- Token expiration handling (401 returns specific error message)

## Test plan

- [x] All 160 tests pass
- [x] 3 new integration tests for notionApiRequest()